### PR TITLE
add github repo parsing example

### DIFF
--- a/inst/README.Rmd
+++ b/inst/README.Rmd
@@ -1,3 +1,6 @@
+---
+output: github_document
+---
 
 ```{r, setup, echo = FALSE, message = FALSE}
 knitr::opts_chunk$set(
@@ -43,6 +46,27 @@ re_match(text = dates, pattern = isodate)
 ```{r}
 isodaten <- "(?<year>[0-9]{4})-(?<month>[0-1][0-9])-(?<day>[0-3][0-9])"
 re_match(text = dates, pattern = isodaten)
+```
+
+```{r}
+github_repos <- c("metacran/crandb", "jeroenooms/curl@v0.9.3",
+                  "jimhester/covr#47", "hadley/dplyr@*release",
+                  "mangothecat/remotes@550a3c7d3f9e1493a2ba",
+                  "/$&@R64&3")
+owner_rx <- "(?:([^/]+)/)?"
+repo_rx <- "([^/@#]+)"
+subdir_rx <- "(?:/([^@#]*[^@#/]))?"
+ref_rx <- "(?:@([^*].*))"
+pull_rx <- "(?:#([0-9]+))"
+release_rx <- "(?:@([*]release))"
+ref_or_pull_or_release_rx <-
+  sprintf("(?:%s|%s|%s)?", ref_rx, pull_rx, release_rx)
+github_rx <- sprintf("^(?:%s%s%s%s|(.*))$",
+                     owner_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx)
+out <- re_match(text = github_repos, pattern = github_rx)
+colnames(out) <-
+  c(".input", "owner", "repo", "subdir", "ref", "pull", "release", "catchall")
+out
 ```
 
 ## License

--- a/inst/README.Rmd
+++ b/inst/README.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 
 > Match Regular Expressions with a Nicer 'API'
 
-[![Linux Build Status](https://travis-ci.org/MangoTheCat/rematch.svg?branch=master)](https://travis-ci.org/MangoTheCat/rematch)
+[![Linux Build Status](https://travis-ci.org/MangoTheCat/rematch.svg?branch=master)](https://api.travis-ci.org/MangoTheCat/rematch.svg?branch=master)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/MangoTheCat/rematch?svg=true)](https://ci.appveyor.com/project/gaborcsardi/rematch)
 [![](http://www.r-pkg.org/badges/version/rematch)](http://www.r-pkg.org/pkg/rematch)
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/rematch)](http://www.r-pkg.org/pkg/rematch)
@@ -53,19 +53,17 @@ github_repos <- c("metacran/crandb", "jeroenooms/curl@v0.9.3",
                   "jimhester/covr#47", "hadley/dplyr@*release",
                   "mangothecat/remotes@550a3c7d3f9e1493a2ba",
                   "/$&@R64&3")
-owner_rx <- "(?:([^/]+)/)?"
-repo_rx <- "([^/@#]+)"
-subdir_rx <- "(?:/([^@#]*[^@#/]))?"
-ref_rx <- "(?:@([^*].*))"
-pull_rx <- "(?:#([0-9]+))"
-release_rx <- "(?:@([*]release))"
+owner_rx <- "(?:(?<owner>[^/]+)/)?"
+repo_rx <- "(?<repo>[^/@#]+)"
+subdir_rx <- "(?:/(?<subdir>[^@#]*[^@#/]))?"
+ref_rx <- "(?:@(?<ref>[^*].*))"
+pull_rx <- "(?:#(?<pull>[0-9]+))"
+release_rx <- "(?:@(?<release>[*]release))"
 ref_or_pull_or_release_rx <-
   sprintf("(?:%s|%s|%s)?", ref_rx, pull_rx, release_rx)
-github_rx <- sprintf("^(?:%s%s%s%s|(.*))$",
+github_rx <- sprintf("^(?:%s%s%s%s|(?<catchall>.*))$",
                      owner_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx)
 out <- re_match(text = github_repos, pattern = github_rx)
-colnames(out) <-
-  c(".input", "owner", "repo", "subdir", "ref", "pull", "release", "catchall")
 out
 ```
 

--- a/inst/README.md
+++ b/inst/README.md
@@ -4,7 +4,7 @@ rematch
 
 > Match Regular Expressions with a Nicer 'API'
 
-[![Linux Build Status](https://travis-ci.org/MangoTheCat/rematch.svg?branch=master)](https://travis-ci.org/MangoTheCat/rematch) [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/MangoTheCat/rematch?svg=true)](https://ci.appveyor.com/project/gaborcsardi/rematch) [![](http://www.r-pkg.org/badges/version/rematch)](http://www.r-pkg.org/pkg/rematch) [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/rematch)](http://www.r-pkg.org/pkg/rematch) [![Coverage Status](https://img.shields.io/codecov/c/github/MangoTheCat/rematch/master.svg)](https://codecov.io/github/MangoTheCat/rematch?branch=master)
+[![Linux Build Status](https://travis-ci.org/MangoTheCat/rematch.svg?branch=master)](https://api.travis-ci.org/MangoTheCat/rematch.svg?branch=master) [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/MangoTheCat/rematch?svg=true)](https://ci.appveyor.com/project/gaborcsardi/rematch) [![](http://www.r-pkg.org/badges/version/rematch)](http://www.r-pkg.org/pkg/rematch) [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/rematch)](http://www.r-pkg.org/pkg/rematch) [![Coverage Status](https://img.shields.io/codecov/c/github/MangoTheCat/rematch/master.svg)](https://codecov.io/github/MangoTheCat/rematch?branch=master)
 
 A small wrapper on 'regexpr' to extract the matches and captured groups from the match of a regular expression to a character vector.
 
@@ -57,23 +57,21 @@ github_repos <- c("metacran/crandb", "jeroenooms/curl@v0.9.3",
                   "jimhester/covr#47", "hadley/dplyr@*release",
                   "mangothecat/remotes@550a3c7d3f9e1493a2ba",
                   "/$&@R64&3")
-owner_rx <- "(?:([^/]+)/)?"
-repo_rx <- "([^/@#]+)"
-subdir_rx <- "(?:/([^@#]*[^@#/]))?"
-ref_rx <- "(?:@([^*].*))"
-pull_rx <- "(?:#([0-9]+))"
-release_rx <- "(?:@([*]release))"
+owner_rx <- "(?:(?<owner>[^/]+)/)?"
+repo_rx <- "(?<repo>[^/@#]+)"
+subdir_rx <- "(?:/(?<subdir>[^@#]*[^@#/]))?"
+ref_rx <- "(?:@(?<ref>[^*].*))"
+pull_rx <- "(?:#(?<pull>[0-9]+))"
+release_rx <- "(?:@(?<release>[*]release))"
 ref_or_pull_or_release_rx <-
   sprintf("(?:%s|%s|%s)?", ref_rx, pull_rx, release_rx)
-github_rx <- sprintf("^(?:%s%s%s%s|(.*))$",
+github_rx <- sprintf("^(?:%s%s%s%s|(?<catchall>.*))$",
                      owner_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx)
 out <- re_match(text = github_repos, pattern = github_rx)
-colnames(out) <-
-  c(".input", "owner", "repo", "subdir", "ref", "pull", "release", "catchall")
 out
 ```
 
-    #>      .input                                     owner         repo     
+    #>      .match                                     owner         repo     
     #> [1,] "metacran/crandb"                          "metacran"    "crandb" 
     #> [2,] "jeroenooms/curl@v0.9.3"                   "jeroenooms"  "curl"   
     #> [3,] "jimhester/covr#47"                        "jimhester"   "covr"   

--- a/inst/README.md
+++ b/inst/README.md
@@ -4,7 +4,7 @@ rematch
 
 > Match Regular Expressions with a Nicer 'API'
 
-[![Linux Build Status](https://travis-ci.org/MangoTheCat/rematch.svg?branch=master)](https://travis-ci.org/MangoTheCat/rematch) [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/MangoTheCat/rematch?svg=true)](https://ci.appveyor.com/project/gaborcsardi/rematch) [![](http://www.r-pkg.org/badges/version/rematch)](http://www.r-pkg.org/pkg/rematch) [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/rematch)](http://www.r-pkg.org/pkg/rematch)
+[![Linux Build Status](https://travis-ci.org/MangoTheCat/rematch.svg?branch=master)](https://travis-ci.org/MangoTheCat/rematch) [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/MangoTheCat/rematch?svg=true)](https://ci.appveyor.com/project/gaborcsardi/rematch) [![](http://www.r-pkg.org/badges/version/rematch)](http://www.r-pkg.org/pkg/rematch) [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/rematch)](http://www.r-pkg.org/pkg/rematch) [![Coverage Status](https://img.shields.io/codecov/c/github/MangoTheCat/rematch/master.svg)](https://codecov.io/github/MangoTheCat/rematch?branch=master)
 
 A small wrapper on 'regexpr' to extract the matches and captured groups from the match of a regular expression to a character vector.
 

--- a/inst/README.md
+++ b/inst/README.md
@@ -1,69 +1,94 @@
 
-
-
-# rematch
+rematch
+=======
 
 > Match Regular Expressions with a Nicer 'API'
 
-[![Linux Build Status](https://travis-ci.org/MangoTheCat/rematch.svg?branch=master)](https://travis-ci.org/MangoTheCat/rematch)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/MangoTheCat/rematch?svg=true)](https://ci.appveyor.com/project/gaborcsardi/rematch)
-[![](http://www.r-pkg.org/badges/version/rematch)](http://www.r-pkg.org/pkg/rematch)
-[![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/rematch)](http://www.r-pkg.org/pkg/rematch)
-[![Coverage Status](https://img.shields.io/codecov/c/github/MangoTheCat/rematch/master.svg)](https://codecov.io/github/MangoTheCat/rematch?branch=master)
+[![Linux Build Status](https://travis-ci.org/MangoTheCat/rematch.svg?branch=master)](https://travis-ci.org/MangoTheCat/rematch) [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/MangoTheCat/rematch?svg=true)](https://ci.appveyor.com/project/gaborcsardi/rematch) [![](http://www.r-pkg.org/badges/version/rematch)](http://www.r-pkg.org/pkg/rematch) [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/rematch)](http://www.r-pkg.org/pkg/rematch)
 
-A small wrapper on 'regexpr' to extract the matches and captured groups
-from the match of a regular expression to a character vector.
+A small wrapper on 'regexpr' to extract the matches and captured groups from the match of a regular expression to a character vector.
 
-## Installation
+Installation
+------------
 
-
-```r
+``` r
 source("https://install-github.me/MangoTheCat/rematch")
 ```
 
-## Usage
+Usage
+-----
 
-
-```r
+``` r
 library(rematch)
 ```
 
-
-```r
+``` r
 dates <- c("2016-04-20", "1977-08-08", "not a date", "2016",
   "76-03-02", "2012-06-30", "2015-01-21 19:58")
 isodate <- "([0-9]{4})-([0-1][0-9])-([0-3][0-9])"
 re_match(text = dates, pattern = isodate)
 ```
 
-```
-#>      .match                       
-#> [1,] "2016-04-20" "2016" "04" "20"
-#> [2,] "1977-08-08" "1977" "08" "08"
-#> [3,] NA           NA     NA   NA  
-#> [4,] NA           NA     NA   NA  
-#> [5,] NA           NA     NA   NA  
-#> [6,] "2012-06-30" "2012" "06" "30"
-#> [7,] "2015-01-21" "2015" "01" "21"
-```
+    #>      .match                       
+    #> [1,] "2016-04-20" "2016" "04" "20"
+    #> [2,] "1977-08-08" "1977" "08" "08"
+    #> [3,] NA           NA     NA   NA  
+    #> [4,] NA           NA     NA   NA  
+    #> [5,] NA           NA     NA   NA  
+    #> [6,] "2012-06-30" "2012" "06" "30"
+    #> [7,] "2015-01-21" "2015" "01" "21"
 
-
-```r
+``` r
 isodaten <- "(?<year>[0-9]{4})-(?<month>[0-1][0-9])-(?<day>[0-3][0-9])"
 re_match(text = dates, pattern = isodaten)
 ```
 
-```
-#>      .match       year   month day 
-#> [1,] "2016-04-20" "2016" "04"  "20"
-#> [2,] "1977-08-08" "1977" "08"  "08"
-#> [3,] NA           NA     NA    NA  
-#> [4,] NA           NA     NA    NA  
-#> [5,] NA           NA     NA    NA  
-#> [6,] "2012-06-30" "2012" "06"  "30"
-#> [7,] "2015-01-21" "2015" "01"  "21"
+    #>      .match       year   month day 
+    #> [1,] "2016-04-20" "2016" "04"  "20"
+    #> [2,] "1977-08-08" "1977" "08"  "08"
+    #> [3,] NA           NA     NA    NA  
+    #> [4,] NA           NA     NA    NA  
+    #> [5,] NA           NA     NA    NA  
+    #> [6,] "2012-06-30" "2012" "06"  "30"
+    #> [7,] "2015-01-21" "2015" "01"  "21"
+
+``` r
+github_repos <- c("metacran/crandb", "jeroenooms/curl@v0.9.3",
+                  "jimhester/covr#47", "hadley/dplyr@*release",
+                  "mangothecat/remotes@550a3c7d3f9e1493a2ba",
+                  "/$&@R64&3")
+owner_rx <- "(?:([^/]+)/)?"
+repo_rx <- "([^/@#]+)"
+subdir_rx <- "(?:/([^@#]*[^@#/]))?"
+ref_rx <- "(?:@([^*].*))"
+pull_rx <- "(?:#([0-9]+))"
+release_rx <- "(?:@([*]release))"
+ref_or_pull_or_release_rx <-
+  sprintf("(?:%s|%s|%s)?", ref_rx, pull_rx, release_rx)
+github_rx <- sprintf("^(?:%s%s%s%s|(.*))$",
+                     owner_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx)
+out <- re_match(text = github_repos, pattern = github_rx)
+colnames(out) <-
+  c(".input", "owner", "repo", "subdir", "ref", "pull", "release", "catchall")
+out
 ```
 
-## License
+    #>      .input                                     owner         repo     
+    #> [1,] "metacran/crandb"                          "metacran"    "crandb" 
+    #> [2,] "jeroenooms/curl@v0.9.3"                   "jeroenooms"  "curl"   
+    #> [3,] "jimhester/covr#47"                        "jimhester"   "covr"   
+    #> [4,] "hadley/dplyr@*release"                    "hadley"      "dplyr"  
+    #> [5,] "mangothecat/remotes@550a3c7d3f9e1493a2ba" "mangothecat" "remotes"
+    #> [6,] "/$&@R64&3"                                ""            ""       
+    #>      subdir ref                    pull release    catchall   
+    #> [1,] ""     ""                     ""   ""         ""         
+    #> [2,] ""     "v0.9.3"               ""   ""         ""         
+    #> [3,] ""     ""                     "47" ""         ""         
+    #> [4,] ""     ""                     ""   "*release" ""         
+    #> [5,] ""     "550a3c7d3f9e1493a2ba" ""   ""         ""         
+    #> [6,] ""     ""                     ""   ""         "/$&@R64&3"
+
+License
+-------
 
 MIT © Mango Solutions


### PR DESCRIPTION
I don't expect you to actually merge this. It is to help me ask 2 questions:
- Do you like this as an added example for the README?
- I was hoping to solve my "named non-capturing group" problem by providing names of output columns to, e.g., `re_match()`. Do you like or hate that idea? If you dislike, I can just do it the way I've done here, i.e. after the fact.
