### PR TITLE
Output as tibbles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ LazyData: true
 URL: https://github.com/MangoTheCat/rematch
 BugReports: https://github.com/MangoTheCat/rematch/issues
 RoxygenNote: 5.0.1.9000
+Imports: tibble
 Suggests: 
     covr,
     testthat

--- a/inst/README.md
+++ b/inst/README.md
@@ -104,3 +104,22 @@ out
 ## License
 
 MIT © Mango Solutions
+
+
+f <- function(x) {
+  switch(x,
+      a = {  1 },
+      b = 2,
+      c = d <- 1)
+}
+trace_calls(f)
+
+DataFrame(a=I(c(list(c(1:100)))))
+data_frame(a=c(list(c(1:100))))
+fit <- lm(cyl~disp, data = mtcars)
+DataFrame(a=I(c(list(c(1:100)), list(fit))))
+as_data_frame(mtcars)
+mt <- mtcars
+rownames(mt) <- NULL
+as(mt, "DataFrame")
+

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -4,31 +4,24 @@ context("re_match_all")
 test_that("corner cases", {
 
   res <- re_match_all("", c("foo", "bar"))
-  expect_equal(
+  expect_identical(
     res,
-    list(
-      cbind(.match = c("", "", "")),
-      cbind(.match = c("", "", ""))
-    )
+    tibble::data_frame(.match = c(list(c("", "", "")), list(c("", "", ""))))
   )
 
   res <- re_match_all("", c("", "bar"))
-  expect_equal(
+  expect_identical(
     res,
-    list(
-      cbind(.match = ""),
-      cbind(.match = c("", "", ""))
-    )
+    tibble::data_frame(
+      .match = c(list(""), list(c("", "", ""))))
   )
 
-  res <- re_match_all("", character())
-  expect_equal(res, list())
+  expect_error(re_match_all("", character()))
 
-  res <- re_match_all("foo", character())
-  expect_equal(res, list())
+  expect_error(re_match_all("foo", character()))
 
   res <- re_match_all("foo", "not")
-  expect_equal(res, list(cbind(.match = character())))
+  expect_identical(res, tibble::data_frame(.match = list(NA_character_)))
 })
 
 
@@ -37,30 +30,33 @@ test_that("capture groups", {
   pattern <- "([0-9]+)"
 
   res <- re_match_all(pattern, c("123xxxx456", "", "xxx", "1", "123"))
-  expect_equal(
+  expect_identical(
     res,
-    list(
-      cbind(.match = c("123", "456"), c("123", "456")),
-      cbind(.match = character(), character()),
-      cbind(.match = character(), character()),
-      cbind(.match = "1", "1"),
-      cbind(.match = "123", "123")
-    )
+    tibble::data_frame(
+      .match = c(
+          list(c("123", "456")),
+            list(NA_character_),
+            list(NA_character_),
+            list("1"),
+            list("123")),
+      V1 = c(
+          list(c("123", "456")),
+            list(""),
+            list(""),
+            list("1"),
+            list("123")))
   )
 
 })
 
 
-test_that("scalar text with capure groups", {
+test_that("scalar text with capture groups", {
 
   res <- re_match_all("\\b(\\w+)\\b", "foo bar")
-  expect_equal(res, list(cbind(.match = c("foo", "bar"), c("foo", "bar"))))
+  expect_identical(res,
+    tibble::data_frame(.match = list(c("foo", "bar")), V1 = list(c("foo", "bar"))))
 
   res <- re_match_all("\\b(?<word>\\w+)\\b", "foo bar")
-  expect_equal(
-    res,
-    list(
-      cbind(.match = c("foo", "bar"), word = c("foo", "bar"))
-    )
-  )
+  expect_identical(res,
+    tibble::data_frame(.match = list(c("foo", "bar")), word = list(c("foo", "bar"))))
 })

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -4,28 +4,28 @@ context("rematch")
 test_that("corner cases", {
 
   res <- re_match("", c("foo", "bar"))
-  expect_equal(res, cbind(.match = c("", "")))
+  expect_equal(res, tibble::data_frame(.match = c("", "")))
 
   res <- re_match("", c("foo", "", "bar"))
-  expect_equal(res, cbind(.match = c("", "", "")))
+  expect_equal(res, tibble::data_frame(.match = c("", "", "")))
 
   res <- re_match("", character())
-  expect_equal(res, cbind(.match = character()))
+  expect_identical(res, tibble::data_frame(.match = character()))
 
   res <- re_match("foo", character())
-  expect_equal(res, cbind(.match = character()))
+  expect_identical(res, tibble::data_frame(.match = character()))
 
   res <- re_match("foo (g1) (g2)", character())
-  expect_equal(res, cbind(.match = character(), character(), character()))
+  expect_identical(res, tibble::data_frame(.match = character(), V1 = character(), V2 = character()))
 
   res <- re_match("foo (g1) (?<name>g2)", character())
-  expect_equal(
+  expect_identical(
     res,
-    cbind(.match = character(), character(), name = character())
+    tibble::data_frame(.match = character(), V1 = character(), name = character())
   )
 
   res <- re_match("foo", "not")
-  expect_equal(res, cbind(.match = NA_character_))
+  expect_equal(res, tibble::data_frame(.match = NA_character_))
 })
 
 
@@ -36,18 +36,18 @@ test_that("not so corner cases", {
   isodate <- "([0-9]{4})-([0-1][0-9])-([0-3][0-9])"
   expect_equal(
     re_match(text = dates, pattern = isodate),
-    cbind(
+    tibble::data_frame(
       .match = c(dates[1:2], NA, NA, NA, "2012-06-30", "2015-01-21"),
-      c("2016", "1977", NA, NA, NA, "2012", "2015"),
-      c("04", "08", NA, NA, NA, "06", "01"),
-      c("20", "08", NA, NA, NA, "30", "21")
+      V1 = c("2016", "1977", NA, NA, NA, "2012", "2015"),
+      V2 = c("04", "08", NA, NA, NA, "06", "01"),
+      V3 = c("20", "08", NA, NA, NA, "30", "21")
     )
   )
 
   isodaten <- "(?<year>[0-9]{4})-(?<month>[0-1][0-9])-(?<day>[0-3][0-9])"
   expect_equal(
     re_match(text = dates, pattern = isodaten),
-    cbind(
+    tibble::data_frame(
       .match = c(dates[1:2], NA, NA, NA, "2012-06-30", "2015-01-21"),
       year = c("2016", "1977", NA, NA, NA, "2012", "2015"),
       month = c("04", "08", NA, NA, NA, "06", "01"),
@@ -60,7 +60,7 @@ test_that("not so corner cases", {
 test_that("UTF8", {
 
   res <- re_match("Gábor", c("Gábor Csárdi"))
-  expect_equal(res, cbind(.match = "Gábor"))
+  expect_equal(res, tibble::data_frame(.match = "Gábor"))
 
 })
 
@@ -68,9 +68,9 @@ test_that("UTF8", {
 test_that("text is scalar & capture groups", {
 
   res <- re_match("(\\w+) (\\w+)", "foo bar")
-  expect_equal(res, cbind(.match = "foo bar", "foo", "bar"))
+  expect_equal(res, tibble::data_frame(.match = "foo bar", V1 = "foo", V2 = "bar"))
 
   res <- re_match("(?<g1>\\w+) (?<g2>\\w+)", "foo bar")
-  expect_equal(res, cbind(.match = "foo bar", g1 = "foo", g2 = "bar"))
+  expect_equal(res, tibble::data_frame(.match = "foo bar", g1 = "foo", g2 = "bar"))
 
 })


### PR DESCRIPTION
re_match outputs a simple data frame, re_match_all uses list elements.

The implementation is kind of annoying to write, but seems to work...

``` r
re_match("\\w(?<second>\\w)", c("some", "words"))
#> # A tibble: 2 x 2
#>   .match second
#>    <chr>  <chr>
#> 1     so      o
#> 2     wo      o
re_match_all("(\\w+) (?<test>\\w+)", c("a word another word", "123 456 789"))
#> # A tibble: 2 x 3
#>      .match        V1      test
#>      <list>    <list>    <list>
#> 1 <chr [2]> <chr [2]> <chr [2]>
#> 2 <chr [1]> <chr [1]> <chr [1]>
```
